### PR TITLE
fix operatorsAliases

### DIFF
--- a/src/models/index.js
+++ b/src/models/index.js
@@ -6,6 +6,7 @@ const sequelize = new Sequelize(
   process.env.DATABASE_PASSWORD,
   {
     dialect: 'postgres',
+    operatorsAliases: false,
   },
 );
 


### PR DESCRIPTION
https://github.com/sequelize/sequelize/issues/8417#issuecomment-461150731

Also from command line:

sequelize deprecated String based operators are now deprecated. Please use Symbol based operators for better security, read more at http://docs.sequelizejs.com/manual/tutorial/querying.html#operators node_modules/sequelize/lib/sequelize.js:242:13